### PR TITLE
Failsafe for addModels receiving string/number

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -619,6 +619,7 @@ function mTarget.addBone(id,title,icon,bone,radius,onSelect,items,vars,res,canIn
 end
 
 function mTarget.addModelBones(id,title,icon,model,bones,radius,onSelect,items,vars,res,canInteract)
+  if type(models) ~= 'table' then models = {models} end
   local targetIds = {}
 
   for i=1,#bones do


### PR DESCRIPTION
Some other target scripts like qTarget may allow adding models by string or integer one at a time instead of requiring a table of models to add. This will check the incoming data type and if it is not a table, it will make it a table to prevent errors.